### PR TITLE
new api apiObserver

### DIFF
--- a/core/src/main/java/com/crocodic/core/api/ApiObserver.kt
+++ b/core/src/main/java/com/crocodic/core/api/ApiObserver.kt
@@ -8,9 +8,18 @@ import org.json.JSONObject
  * Created by @yzzzd on 4/22/18.
  */
 
-class ApiObserver(block: suspend () -> String, dispatcher: CoroutineDispatcher, toast: Boolean = false, responseListener: ResponseListener) {
+class ApiObserver(
+    block: suspend () -> String,
+    dispatcher: CoroutineDispatcher,
+    toast: Boolean = false,
+    responseListener: ResponseListener
+) {
 
-    constructor(block: suspend () -> String, toast: Boolean = false, responseListener: ResponseListener): this(block, Dispatchers.IO, toast, responseListener)
+    constructor(
+        block: suspend () -> String,
+        toast: Boolean = false,
+        responseListener: ResponseListener
+    ) : this(block, Dispatchers.IO, toast, responseListener)
 
     init {
         val exception = CoroutineExceptionHandler { coroutineContext, throwable ->
@@ -31,5 +40,37 @@ class ApiObserver(block: suspend () -> String, dispatcher: CoroutineDispatcher, 
         fun onError(response: ApiResponse) {
             EventBus.getDefault().post(response)
         }
+    }
+}
+
+/**
+ * @param block suspend function
+ * @param dispatcher Default [Dispatchers.IO]
+ * @param toast Default false
+ * @param listener Anonymus class to handle response
+ */
+suspend fun apiObserver(
+    block: suspend () -> String,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    toast: Boolean = false,
+    listener: ResponseListener
+) {
+    try {
+        val responseJSON = withContext(dispatcher) {
+            val response = block.invoke()
+            JSONObject(response)
+        }
+        listener.onSuccess(responseJSON)
+    } catch (t: Throwable) {
+        val response = ApiResponse(isToast = toast).responseError(t)
+        listener.onError(response)
+    }
+}
+
+interface ResponseListener {
+    suspend fun onSuccess(response: JSONObject)
+
+    suspend fun onError(response: ApiResponse) {
+        EventBus.getDefault().post(response)
     }
 }


### PR DESCRIPTION
apiObserver cara baru untuk melakukan request dengan mengikuti [best practice kotlin coroutine](https://developer.android.com/kotlin/coroutines/coroutines-best-practices)

#### Usage

```kt
fun requestSinglePost() {
        _posts.value = Resource.Loading()
        viewModelScope.launch {
            apiObserver({service.post(1)}, listener = object : ResponseListener {
                override suspend fun onSuccess(response: JSONObject) {
                    _posts.postValue(Resource.Success(listOf(response.toPost())))
                }
                override suspend fun onError(response: ApiResponse) {
                    super.onError(response) // panggil super jika ingin error di handle EventBuzz
                }
            })
        }
    }
```

