### PR TITLE
migrate to ListAdapter

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,10 +3,12 @@
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">
       <map>
+        <entry key="../../../../../../../layout/custom_preview.xml" value="0.23020833333333332" />
         <entry key="../../../../../../layout/custom_preview.xml" value="0.23333333333333334" />
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.4046875" />
         <entry key="app/src/main/res/layout/item_list_sample.xml" value="0.4046875" />
         <entry key="app/src/main/res/layout/item_main.xml" value="0.4046875" />
+        <entry key="app/src/main/res/layout/item_task.xml" value="0.20416666666666666" />
         <entry key="core/src/main/res/drawable/background_btn_blue.xml" value="0.42083333333333334" />
         <entry key="core/src/main/res/drawable/background_btn_gray.xml" value="0.42083333333333334" />
         <entry key="core/src/main/res/drawable/background_btn_red.xml" value="0.42083333333333334" />

--- a/app/src/main/java/com/nuryazid/androidcore/ui/main/MainAdapter.kt
+++ b/app/src/main/java/com/nuryazid/androidcore/ui/main/MainAdapter.kt
@@ -1,13 +1,20 @@
 package com.nuryazid.androidcore.ui.main
 
+import com.crocodic.core.base.adapter.PaginationAdapter
 import com.crocodic.core.base.adapter.SingleClickListAdapter
 import com.nuryazid.androidcore.R
 import com.nuryazid.androidcore.data.DataExample
 import com.nuryazid.androidcore.databinding.ItemListSampleBinding
 
-class MainAdapter: SingleClickListAdapter<ItemListSampleBinding, DataExample>(R.layout.item_list_sample) {
-    override fun onBindViewHolder(holder: ItemViewHolder<ItemListSampleBinding, DataExample>, position: Int) {
-        items[position]?.let { item ->
+class MainAdapter : SingleClickListAdapter<ItemListSampleBinding, DataExample>(
+    R.layout.item_list_sample,
+    PaginationAdapter.DiffUtilCallback()
+) {
+    override fun onBindViewHolder(
+        holder: ItemViewHolder<ItemListSampleBinding, DataExample>,
+        position: Int
+    ) {
+        getItem(position)?.let { item ->
             holder.bind(item)
             holder.binding.tvName.setOnClickListener {
 

--- a/core/src/main/java/com/crocodic/core/base/adapter/CoreListAdapter.kt
+++ b/core/src/main/java/com/crocodic/core/base/adapter/CoreListAdapter.kt
@@ -4,6 +4,8 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.crocodic.core.BR
 import com.crocodic.core.R
@@ -12,58 +14,55 @@ import com.crocodic.core.R
  * Created by @yzzzd on 4/19/18.
  */
 
-open class CoreListAdapter<VB: ViewDataBinding, T: Any?>(private var layoutRes: Int) : RecyclerView.Adapter<CoreListAdapter.ItemViewHolder<VB, T>>() {
+/**
+ * @constructor [@DrawableRes]
+ * @constructor diffUtil, you can create a instance DiffUtil from [PaginationAdapter.DiffUtilCallback]
+ */
+open class CoreListAdapter<VB : ViewDataBinding, T : Any?>(
+    private var layoutRes: Int,
+    diffUtil: DiffUtil.ItemCallback<T>
+) : ListAdapter<T, CoreListAdapter.ItemViewHolder<VB, T>>(diffUtil) {
 
-    var items: ArrayList<T?> = ArrayList()
     var onItemClick: ((position: Int, data: T?) -> Unit)? = null
 
-    fun initItem(items: ArrayList<T?>, onItemClick: ((position: Int, data: T?) -> Unit)? = null) : CoreListAdapter<VB, T> {
-        this.items = items
-        this.onItemClick = onItemClick
-        return this
-    }
-
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ItemViewHolder<VB, T> {
-        val binding = DataBindingUtil.inflate<VB>(LayoutInflater.from(parent.context), if (viewType == VIEW_TYPE_LOADING) R.layout.cr_item_load_more else layoutRes, parent, false)
+        val finalViewType = when (viewType) {
+            VIEW_TYPE_LOADING -> R.layout.cr_item_load_more
+            else -> layoutRes
+        }
+        val binding = DataBindingUtil.inflate<VB>(
+            LayoutInflater.from(parent.context),
+            finalViewType,
+            parent,
+            false
+        )
         return ItemViewHolder(binding)
     }
 
     override fun onBindViewHolder(holder: ItemViewHolder<VB, T>, position: Int) {
-        items[position]?.let { item ->
+        getItem(position)?.let { item ->
             holder.bind(item)
-            onItemClick?.let { holder.itemView.setOnClickListener { it(position, item) } }
+            onItemClick?.let { `fun` ->
+                holder.itemView.setOnClickListener {
+                    `fun`.invoke(
+                        position,
+                        item
+                    )
+                }
+            }
         }
     }
 
-    override fun getItemCount(): Int {
-        return items.size
-    }
-
     override fun getItemViewType(position: Int): Int {
-        return if (items[position] == null) {
+        return if (getItem(position) == null) {
             VIEW_TYPE_LOADING
         } else {
             VIEW_TYPE_ITEM
         }
     }
 
-    fun addNull() {
-        if (!items.contains(null)) {
-            items.add(null)
-            notifyDataSetChanged()
-            //notifyItemInserted(items.lastIndex)
-        }
-    }
-
-    fun removeNull() {
-        if (items.contains(null)) {
-            items.remove(null)
-            notifyDataSetChanged()
-            //notifyItemRemoved(items.size)
-        }
-    }
-
-    class ItemViewHolder<VB : ViewDataBinding, T: Any?>(val binding: VB) : RecyclerView.ViewHolder(binding.root) {
+    class ItemViewHolder<VB : ViewDataBinding, T : Any?>(val binding: VB) :
+        RecyclerView.ViewHolder(binding.root) {
         fun bind(data: T?) {
             binding.setVariable(BR.data, data)
             binding.executePendingBindings()

--- a/core/src/main/java/com/crocodic/core/base/adapter/SingleClickListAdapter.kt
+++ b/core/src/main/java/com/crocodic/core/base/adapter/SingleClickListAdapter.kt
@@ -2,20 +2,29 @@ package com.crocodic.core.base.adapter
 
 import android.view.View
 import androidx.databinding.ViewDataBinding
+import androidx.recyclerview.widget.DiffUtil
 import com.crocodic.core.helper.util.ClickPrevention
 
 /**
  * Created by @yzzzd on 4/19/18.
  */
 
-open class SingleClickListAdapter<VB: ViewDataBinding, T: Any?>(private var layoutRes: Int) : CoreListAdapter<VB, T>(layoutRes) {
+/**
+ * @constructor [@DrawableRes]
+ * @constructor diffUtil, you can create a instance DiffUtil from [PaginationAdapter.DiffUtilCallback]
+ */
+open class SingleClickListAdapter<VB : ViewDataBinding, T : Any?>(
+    layoutRes: Int,
+    diffUtil: DiffUtil.ItemCallback<T>
+) : CoreListAdapter<VB, T>(layoutRes, diffUtil) {
+
     override fun onBindViewHolder(holder: ItemViewHolder<VB, T>, position: Int) {
-        items[holder.adapterPosition]?.let { item ->
+        getItem(holder.bindingAdapterPosition)?.let { item ->
             holder.bind(item)
-            onItemClick?.let {
+            onItemClick?.let { `fun` ->
                 holder.itemView.setOnClickListener(object : ClickPrevention {
                     override fun onClick(v: View?) {
-                        it(holder.adapterPosition, item)
+                        `fun`.invoke(holder.bindingAdapterPosition, item)
                         super.onClick(v)
                     }
                 })


### PR DESCRIPTION
## Migrasi ke ListAdapter

Kelebihan ListAdapter

- Support DIffUtil
- Membandingkan dua list di background thread

Penggunan ListAdapter cocok dengan data yang dynamic

[docs](https://developer.android.com/reference/androidx/recyclerview/widget/ListAdapter)

## Usage

```kt
@AndroidEntryPoint
class TasksFragment : BaseFragment<FragmentTasksBinding>() {

    private val viewModel: TasksViewModel by viewModels()

    // Step 1
    private lateinit var tasksAdapter: SingleClickListAdapter<FragmentTasksBinding, Task>

    private fun observe() {
        viewLifecycleOwner.lifecycleScope.launch {
            viewModel.tasksUiState
                .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
                .collectLatest {
                    val (isLoading, tasks) = it
                    when {
                        isLoading -> showUiLoading()
                        !isLoading && tasks.isNotEmpty() -> {
                            showUiTasks()
                            // Step 3
                            tasksAdapter.submitList(tasks) // add list using submitList method
                        }
                        !isLoading && tasks.isEmpty() -> showUiEmptyTasks()
                    }
                }
        }
    }
    private fun initView() {
        // Step 2
        tasksAdapter = SingleClickListAdapter(R.layout.item_task, DiffUtilCallback())
        tasksAdapter.onItemClick = { position: Int, data: Task? ->
            Toast.makeText(requireContext(), "$position + ${data?.title}", Toast.LENGTH_SHORT)
                .show()
        }
        with(binding.rvTasks) {
            setHasFixedSize(true)
            layoutManager = LinearLayoutManager(requireContext())
            adapter = tasksAdapter
        }
    }
}
```