### PR TITLE
make core dialog lifecycle aware

### DIFF
--- a/core/src/main/java/com/crocodic/core/base/activity/NoViewModelActivity.kt
+++ b/core/src/main/java/com/crocodic/core/base/activity/NoViewModelActivity.kt
@@ -50,16 +50,16 @@ abstract class NoViewModelActivity<VB : ViewDataBinding>(@LayoutRes private val 
 
     protected lateinit var binding: VB
 
-    protected val loadingDialog by lazy { LoadingDialog(this) }
+    protected val loadingDialog by lazy { LoadingDialog(this, this) }
 
-    protected val informationDialog by lazy { InformationDialog(this) }
+    protected val informationDialog by lazy { InformationDialog(this, this) }
 
     protected var inAppNotification = true
 
     protected var stateViewHelper: StateViewHelper? = null
 
     protected val expiredDialog by lazy {
-        ExpiredDialog(this) { positive, dialog ->
+        ExpiredDialog(this, this) { positive, dialog ->
             dialog.setLoading()
             if (positive) {
                 authRenewToken()

--- a/core/src/main/java/com/crocodic/core/base/fragment/CoreFragment.kt
+++ b/core/src/main/java/com/crocodic/core/base/fragment/CoreFragment.kt
@@ -10,6 +10,7 @@ import androidx.databinding.ViewDataBinding
 import androidx.fragment.app.Fragment
 import com.crocodic.core.helper.ImagePreviewHelper
 import com.crocodic.core.helper.util.ClickPrevention
+import com.crocodic.core.ui.dialog.LoadingDialog
 
 abstract class CoreFragment<VB : ViewDataBinding>(@LayoutRes private val layoutRes: Int) : Fragment(), ClickPrevention {
 
@@ -19,6 +20,11 @@ abstract class CoreFragment<VB : ViewDataBinding>(@LayoutRes private val layoutR
     open var hasLoadedOnce = false
 
     val imagePreview by lazy { context?.let { ImagePreviewHelper(it) } }
+
+    /**
+     * LoadingDialog will automatically dismiss when state for this fragment reach onDestroyView.
+     */
+    protected val loadingDialog by lazy { context?.let { ctx -> LoadingDialog(ctx, viewLifecycleOwner) } }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = DataBindingUtil.inflate(inflater, layoutRes, container, false)

--- a/core/src/main/java/com/crocodic/core/ui/dialog/AlertDialog.kt
+++ b/core/src/main/java/com/crocodic/core/ui/dialog/AlertDialog.kt
@@ -4,13 +4,18 @@ import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import androidx.annotation.StringRes
+import androidx.lifecycle.LifecycleOwner
 import com.crocodic.core.databinding.CrDialogAlertBinding
 
 /**
  * Created by @yzzzd on 4/22/18.
  */
 
-class AlertDialog(context: Context, onButtonClick: (positive: Boolean, dialog: AlertDialog) -> Unit) : CoreBottomSheetDialog<CrDialogAlertBinding>(context) {
+class AlertDialog(
+    context: Context,
+    lifecycleOwner: LifecycleOwner,
+    onButtonClick: (positive: Boolean, dialog: AlertDialog) -> Unit
+) : CoreBottomSheetDialog<CrDialogAlertBinding>(context, lifecycleOwner) {
 
     override fun getViewBinding() = CrDialogAlertBinding.inflate(LayoutInflater.from(context))
 

--- a/core/src/main/java/com/crocodic/core/ui/dialog/AlertDialog.kt
+++ b/core/src/main/java/com/crocodic/core/ui/dialog/AlertDialog.kt
@@ -10,7 +10,7 @@ import com.crocodic.core.databinding.CrDialogAlertBinding
  * Created by @yzzzd on 4/22/18.
  */
 
-class AlertDialog(context: Context, onButtonClick: (positive: Boolean, dialog: AlertDialog) -> Unit) : CoreDialog<CrDialogAlertBinding>(context) {
+class AlertDialog(context: Context, onButtonClick: (positive: Boolean, dialog: AlertDialog) -> Unit) : CoreBottomSheetDialog<CrDialogAlertBinding>(context) {
 
     override fun getViewBinding() = CrDialogAlertBinding.inflate(LayoutInflater.from(context))
 

--- a/core/src/main/java/com/crocodic/core/ui/dialog/CoreBottomSheetDialog.kt
+++ b/core/src/main/java/com/crocodic/core/ui/dialog/CoreBottomSheetDialog.kt
@@ -47,6 +47,9 @@ abstract class CoreBottomSheetDialog<VB : ViewBinding>(val context: Context, lif
         }
     }
 
+    /**
+     * Override this function to change the dialog to close when the Lifecycle reaches a certain state default `Lifecycle.Event.ON_DESTROY`
+     */
     protected open fun onStateDialogDismiss(): Lifecycle.Event {
         return Lifecycle.Event.ON_DESTROY
     }

--- a/core/src/main/java/com/crocodic/core/ui/dialog/CoreBottomSheetDialog.kt
+++ b/core/src/main/java/com/crocodic/core/ui/dialog/CoreBottomSheetDialog.kt
@@ -10,7 +10,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
  * Created by @yzzzd on 4/22/18.
  */
 
-abstract class CoreDialog<VB : ViewBinding>(val context: Context) {
+abstract class CoreBottomSheetDialog<VB : ViewBinding>(val context: Context) {
 
     protected var binding: VB
     protected var dialog: BottomSheetDialog = BottomSheetDialog(context, R.style.BottomSheetDialog)
@@ -22,7 +22,7 @@ abstract class CoreDialog<VB : ViewBinding>(val context: Context) {
         dialog.setContentView(binding.root)
     }
 
-    fun onDismiss(onDismiss: () -> Unit): CoreDialog<VB> {
+    fun onDismiss(onDismiss: () -> Unit): CoreBottomSheetDialog<VB> {
         dialog.setOnDismissListener {
             onDismiss()
         }
@@ -33,19 +33,19 @@ abstract class CoreDialog<VB : ViewBinding>(val context: Context) {
         return context.getString(res)
     }
 
-    open fun show(): CoreDialog<VB> {
+    open fun show(): CoreBottomSheetDialog<VB> {
         dialog.show()
         return this
     }
 
-    fun setCancelable(cancelable: Boolean): CoreDialog<VB> {
+    fun setCancelable(cancelable: Boolean): CoreBottomSheetDialog<VB> {
         dialog.setCancelable(cancelable)
         return this
     }
 
     fun isShowing() = dialog.isShowing
 
-    open fun dismiss(): CoreDialog<VB> {
+    open fun dismiss(): CoreBottomSheetDialog<VB> {
         if (dialog.isShowing) {
             dialog.dismiss()
         }

--- a/core/src/main/java/com/crocodic/core/ui/dialog/CoreDialog.kt
+++ b/core/src/main/java/com/crocodic/core/ui/dialog/CoreDialog.kt
@@ -1,0 +1,84 @@
+package com.crocodic.core.ui.dialog
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.viewbinding.ViewBinding
+
+/**
+ * Gunakan [CoreBottomSheetDialog] untuk membuat bottom sheet.
+ *
+ * @param context
+ * @param lifecycleOwner jika di dalam activity gunakan `this` keyword dan
+ *                        jika di dalam fragment bisa menggunakan `this`, `requireActivity`, dan `viewLifecycleOwner` (recommended)
+ */
+abstract class CoreDialog<VB : ViewBinding>(val context: Context, lifecycleOwner: LifecycleOwner) {
+
+    protected var binding: VB
+    protected var dialog: androidx.appcompat.app.AlertDialog
+
+    protected abstract fun getViewBinding(): VB
+
+    init {
+        binding = this.getViewBinding()
+        dialog = androidx.appcompat.app.AlertDialog.Builder(context)
+            .setView(binding.root)
+            .create()
+
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                onStateDialogDismiss() -> {
+                    dialog.dismiss()
+                }
+                else -> {}
+            }
+        }
+
+        dialog.setOnShowListener {
+            lifecycleOwner.lifecycle.addObserver(observer)
+        }
+
+        dialog.setOnDismissListener {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+
+    /**
+     * Override this function to change the dialog to close when the Lifecycle reaches a certain state default `Lifecycle.Event.ON_DESTROY`
+     */
+    protected open fun onStateDialogDismiss(): Lifecycle.Event {
+        return Lifecycle.Event.ON_DESTROY
+    }
+
+    fun onDismiss(onDismiss: () -> Unit): CoreDialog<VB> {
+        dialog.setOnDismissListener {
+            onDismiss()
+        }
+        return this
+    }
+
+    protected fun string(@StringRes res: Int): String {
+        return context.getString(res)
+    }
+
+    open fun show(): CoreDialog<VB> {
+        dialog.show()
+        return this
+    }
+
+    fun setCancelable(cancelable: Boolean): CoreDialog<VB> {
+        dialog.setCancelable(cancelable)
+        return this
+    }
+
+    fun isShowing() = dialog.isShowing
+
+    open fun dismiss(): CoreDialog<VB> {
+        if (dialog.isShowing) {
+            dialog.dismiss()
+        }
+        return this
+    }
+}

--- a/core/src/main/java/com/crocodic/core/ui/dialog/ExpiredDialog.kt
+++ b/core/src/main/java/com/crocodic/core/ui/dialog/ExpiredDialog.kt
@@ -3,13 +3,18 @@ package com.crocodic.core.ui.dialog
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
+import androidx.lifecycle.LifecycleOwner
 import com.crocodic.core.databinding.CrDialogExpiredBinding
 
 /**
  * Created by @yzzzd on 4/22/18.
  */
 
-class ExpiredDialog(context: Context, onButtonClick: (positive: Boolean, dialog: ExpiredDialog) -> Unit) : CoreBottomSheetDialog<CrDialogExpiredBinding>(context) {
+class ExpiredDialog(
+    context: Context,
+    lifecycleOwner: LifecycleOwner,
+    onButtonClick: (positive: Boolean, dialog: ExpiredDialog) -> Unit
+) : CoreBottomSheetDialog<CrDialogExpiredBinding>(context, lifecycleOwner) {
 
     override fun getViewBinding() = CrDialogExpiredBinding.inflate(LayoutInflater.from(context))
 

--- a/core/src/main/java/com/crocodic/core/ui/dialog/ExpiredDialog.kt
+++ b/core/src/main/java/com/crocodic/core/ui/dialog/ExpiredDialog.kt
@@ -9,7 +9,7 @@ import com.crocodic.core.databinding.CrDialogExpiredBinding
  * Created by @yzzzd on 4/22/18.
  */
 
-class ExpiredDialog(context: Context, onButtonClick: (positive: Boolean, dialog: ExpiredDialog) -> Unit) : CoreDialog<CrDialogExpiredBinding>(context) {
+class ExpiredDialog(context: Context, onButtonClick: (positive: Boolean, dialog: ExpiredDialog) -> Unit) : CoreBottomSheetDialog<CrDialogExpiredBinding>(context) {
 
     override fun getViewBinding() = CrDialogExpiredBinding.inflate(LayoutInflater.from(context))
 
@@ -52,7 +52,7 @@ class ExpiredDialog(context: Context, onButtonClick: (positive: Boolean, dialog:
         return this
     }
 
-    override fun show(): CoreDialog<CrDialogExpiredBinding> {
+    override fun show(): CoreBottomSheetDialog<CrDialogExpiredBinding> {
         if (isShowing() && stillLoading) {
             setLoading(false)
         }
@@ -64,7 +64,7 @@ class ExpiredDialog(context: Context, onButtonClick: (positive: Boolean, dialog:
         return this
     }
 
-    override fun dismiss(): CoreDialog<CrDialogExpiredBinding> {
+    override fun dismiss(): CoreBottomSheetDialog<CrDialogExpiredBinding> {
         if (isShowing()) {
             setLoading(false)
         }

--- a/core/src/main/java/com/crocodic/core/ui/dialog/InformationDialog.kt
+++ b/core/src/main/java/com/crocodic/core/ui/dialog/InformationDialog.kt
@@ -5,13 +5,14 @@ import android.view.LayoutInflater
 import android.view.View
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import androidx.lifecycle.LifecycleOwner
 import com.crocodic.core.databinding.CrDialogInformationBinding
 
 /**
  * Created by @yzzzd on 4/22/18.
  */
 
-class InformationDialog(context: Context): CoreBottomSheetDialog<CrDialogInformationBinding>(context) {
+class InformationDialog(context: Context, lifecycleOwner: LifecycleOwner): CoreBottomSheetDialog<CrDialogInformationBinding>(context, lifecycleOwner) {
 
     override fun getViewBinding() = CrDialogInformationBinding.inflate(LayoutInflater.from(context))
 

--- a/core/src/main/java/com/crocodic/core/ui/dialog/InformationDialog.kt
+++ b/core/src/main/java/com/crocodic/core/ui/dialog/InformationDialog.kt
@@ -11,7 +11,7 @@ import com.crocodic.core.databinding.CrDialogInformationBinding
  * Created by @yzzzd on 4/22/18.
  */
 
-class InformationDialog(context: Context): CoreDialog<CrDialogInformationBinding>(context) {
+class InformationDialog(context: Context): CoreBottomSheetDialog<CrDialogInformationBinding>(context) {
 
     override fun getViewBinding() = CrDialogInformationBinding.inflate(LayoutInflater.from(context))
 

--- a/core/src/main/java/com/crocodic/core/ui/dialog/LoadingDialog.kt
+++ b/core/src/main/java/com/crocodic/core/ui/dialog/LoadingDialog.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import androidx.lifecycle.LifecycleOwner
 import com.crocodic.core.R
 import com.crocodic.core.databinding.CrDialogLoadingBinding
 
@@ -12,7 +13,7 @@ import com.crocodic.core.databinding.CrDialogLoadingBinding
  * Created by @yzzzd on 4/22/18.
  */
 
-class LoadingDialog(context: Context): CoreBottomSheetDialog<CrDialogLoadingBinding>(context) {
+class LoadingDialog(context: Context, lifecycleOwner: LifecycleOwner): CoreBottomSheetDialog<CrDialogLoadingBinding>(context, lifecycleOwner) {
 
     override fun getViewBinding() = CrDialogLoadingBinding.inflate(LayoutInflater.from(context))
 

--- a/core/src/main/java/com/crocodic/core/ui/dialog/LoadingDialog.kt
+++ b/core/src/main/java/com/crocodic/core/ui/dialog/LoadingDialog.kt
@@ -12,7 +12,7 @@ import com.crocodic.core.databinding.CrDialogLoadingBinding
  * Created by @yzzzd on 4/22/18.
  */
 
-class LoadingDialog(context: Context): CoreDialog<CrDialogLoadingBinding>(context) {
+class LoadingDialog(context: Context): CoreBottomSheetDialog<CrDialogLoadingBinding>(context) {
 
     override fun getViewBinding() = CrDialogLoadingBinding.inflate(LayoutInflater.from(context))
 

--- a/core/src/main/java/com/crocodic/core/ui/dialog/PermissionSettingDialog.kt
+++ b/core/src/main/java/com/crocodic/core/ui/dialog/PermissionSettingDialog.kt
@@ -9,7 +9,7 @@ import com.crocodic.core.databinding.CrDialogPermissionSettingBinding
  * Created by @yzzzd on 4/22/18.
  */
 
-class PermissionSettingDialog(context: Context): CoreDialog<CrDialogPermissionSettingBinding>(context) {
+class PermissionSettingDialog(context: Context): CoreBottomSheetDialog<CrDialogPermissionSettingBinding>(context) {
 
     override fun getViewBinding() = CrDialogPermissionSettingBinding.inflate(LayoutInflater.from(context))
 

--- a/core/src/main/java/com/crocodic/core/ui/dialog/PermissionSettingDialog.kt
+++ b/core/src/main/java/com/crocodic/core/ui/dialog/PermissionSettingDialog.kt
@@ -3,13 +3,14 @@ package com.crocodic.core.ui.dialog
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
+import androidx.lifecycle.LifecycleOwner
 import com.crocodic.core.databinding.CrDialogPermissionSettingBinding
 
 /**
  * Created by @yzzzd on 4/22/18.
  */
 
-class PermissionSettingDialog(context: Context): CoreBottomSheetDialog<CrDialogPermissionSettingBinding>(context) {
+class PermissionSettingDialog(context: Context, lifecycleOwner: LifecycleOwner): CoreBottomSheetDialog<CrDialogPermissionSettingBinding>(context, lifecycleOwner) {
 
     override fun getViewBinding() = CrDialogPermissionSettingBinding.inflate(LayoutInflater.from(context))
 

--- a/core/src/main/java/com/crocodic/core/ui/permission/CameraPermissionActivity.kt
+++ b/core/src/main/java/com/crocodic/core/ui/permission/CameraPermissionActivity.kt
@@ -59,7 +59,7 @@ class CameraPermissionActivity : AppCompatActivity(), ClickPrevention {
             if (allPermissionsGranted(REQUIRED_PERMISSIONS_CAMERA)) {
                 finish()
             } else {
-                PermissionSettingDialog(this)
+                PermissionSettingDialog(this, this)
                     .setContent(R.drawable.img_grant_camera, R.string.cr_info_permission_camera)
                     .onButtonClick {
                         it.dismiss()

--- a/core/src/main/java/com/crocodic/core/ui/permission/LocationPermissionActivity.kt
+++ b/core/src/main/java/com/crocodic/core/ui/permission/LocationPermissionActivity.kt
@@ -58,7 +58,7 @@ class LocationPermissionActivity : AppCompatActivity(), ClickPrevention {
             }
         }
         if (denied) {
-            PermissionSettingDialog(this)
+            PermissionSettingDialog(this, this)
                 .setContent(R.drawable.img_grant_location, R.string.cr_info_permission_location)
                 .onButtonClick {
                     it.dismiss()


### PR DESCRIPTION
## Before 
[Demo dialog tidak mengikuti lifecycle dari fragment, ketika berpindah ke fragment Dashboard dialog masih muncul](https://drive.google.com/file/d/1OwLSzZWpoYCeXm09yo_Y6pplnHiDCnTO/view?usp=sharing)

## After
[Demo dialog yang mengikuti lifecycle, dialog akan dismiss ketika fragment atau activity lifecyclenya mencapai `ON_DESTROY`](https://drive.google.com/file/d/1_8b6hkG8GubW9x6oXBbkRVV6LeI2JEsV/view?usp=sharing)